### PR TITLE
convert tuple parameters to separate params for Python 3

### DIFF
--- a/Part 3 - A slightly More Complex Agent Based Model.ipynb
+++ b/Part 3 - A slightly More Complex Agent Based Model.ipynb
@@ -238,7 +238,7 @@
    "source": [
     "# Create a function in which both agents generate utterances and can learn from each other \n",
     "\n",
-    "def interact((agent1,agent2)): \n",
+    "def interact(agent1,agent2): \n",
     "    \n",
     "    agent1_utterance = choose_utterance(agent1)\n",
     "    agent2_utterance = choose_utterance(agent2)\n",
@@ -253,7 +253,7 @@
     "\n",
     "# Check if it works by uncommenting the \"return\" comment above \n",
     "\n",
-    "interact(([-1,'F'],[1,'S']))"
+    "interact([-1,'F'],[1,'S'])"
    ]
   },
   {
@@ -291,9 +291,9 @@
     "    \n",
     "    for i in range(k):\n",
     "        \n",
-    "        pair = choose_pair(population)\n",
+    "        agent1, agent2 = choose_pair(population)\n",
     "        \n",
-    "        interact(pair)\n",
+    "        interact(agent1, agent2)\n",
     "    \n",
     "    return initial_population, population"
    ]
@@ -522,9 +522,9 @@
     "    \n",
     "    for i in range(k):\n",
     "        \n",
-    "        pair = choose_pair(population)\n",
+    "        agent1, agent2 = choose_pair(population)\n",
     "        \n",
-    "        interact(pair)\n",
+    "        interact(agent1, agent2)\n",
     "        \n",
     "    return initial_population, population"
    ]


### PR DESCRIPTION
While the README does suggest using Python 2, the workbooks also work with Python 3 - almost. By replacing the tuple parameter from the interact functions with two simple parameters, the workbooks are compatible with Python 3.